### PR TITLE
fix: switched analytics init to use named firebase strategy

### DIFF
--- a/src/analytics/base-analytics-integration.ts
+++ b/src/analytics/base-analytics-integration.ts
@@ -1,4 +1,5 @@
-import { AnalyticsService, FirebaseStrategy, StatsigStrategy } from '@curiouslearning/analytics';
+import { AnalyticsService, StatsigStrategy } from '@curiouslearning/analytics';
+import { NamedFirebaseStrategy } from './named-firebase-strategy';
 
 export interface AnalyticsConfig {
     apiKey: string;
@@ -20,7 +21,7 @@ export interface AnalyticsConfig {
  */
 export class BaseAnalyticsIntegration {
     private analyticsService: AnalyticsService;
-    private firebaseStrategy: FirebaseStrategy;
+    private namedFirebaseStrategy: NamedFirebaseStrategy;
     private statsigStrategy: StatsigStrategy;
     private isInitialized: boolean = false;
 
@@ -53,8 +54,7 @@ export class BaseAnalyticsIntegration {
         }
 
         try {
-            this.firebaseStrategy = new FirebaseStrategy({
-                firebaseOptions: {
+            const firebaseOptions = {
                     apiKey: config.apiKey,
                     authDomain: config.authDomain,
                     databaseURL: config.databaseURL,
@@ -63,12 +63,11 @@ export class BaseAnalyticsIntegration {
                     messagingSenderId: config.messagingSenderId,
                     appId: config.appId,
                     measurementId: config.measurementId,
-                },
-                userProperties: {}
-            });
+            };
 
-            await this.firebaseStrategy.initialize();
-            this.analyticsService.register('firebase', this.firebaseStrategy);
+            this.namedFirebaseStrategy = new NamedFirebaseStrategy(firebaseOptions);
+            await this.namedFirebaseStrategy.initialize();
+            this.analyticsService.register('firebase', this.namedFirebaseStrategy);
 
             // Example of Statsig initialization (commented out)
             // this.statsigStrategy = new StatsigStrategy({
@@ -79,10 +78,9 @@ export class BaseAnalyticsIntegration {
             // this.analyticsService.register('statsig', this.statsigStrategy);
 
             this.isInitialized = true;
-            console.log("Analytics service initialized successfully with Firebase and Statsig");
+            console.log("Analytics service initialized successfully.");
         } catch (error) {
-            console.error("Error while initializing analytics:", error);
-            throw error;
+            console.warn("Analytics initialization skipped due to error:", error);
         }
     }
 
@@ -121,7 +119,7 @@ export class BaseAnalyticsIntegration {
      * @returns {any | undefined} The Firebase app instance, or undefined if not initialized.
      */
     get firebaseApp(): any {
-        return this.firebaseStrategy?.firebaseApp;
+        return this.namedFirebaseStrategy?.firebaseApp;
     }
 
     /**

--- a/src/analytics/named-firebase-strategy.ts
+++ b/src/analytics/named-firebase-strategy.ts
@@ -1,0 +1,37 @@
+import { AbstractAnalyticsStrategy } from '@curiouslearning/analytics';
+import { FirebaseApp, FirebaseOptions, initializeApp, deleteApp } from 'firebase/app';
+import { Analytics, getAnalytics, logEvent } from 'firebase/analytics';
+
+const NAMED_APP = 'assessment-survey';
+
+export class NamedFirebaseStrategy extends AbstractAnalyticsStrategy {
+    private app: FirebaseApp | null = null;
+    private analytics: Analytics | null = null;
+
+    constructor(private readonly firebaseOptions: FirebaseOptions) {
+        super();
+    }
+
+    async initialize(): Promise<void> {
+        this.app = initializeApp(this.firebaseOptions, NAMED_APP);
+        this.analytics = getAnalytics(this.app);
+    }
+
+    track(eventName: string, data: any): void {
+        if (this.analytics) {
+            logEvent(this.analytics, eventName, data);
+        }
+    }
+
+    get firebaseApp(): FirebaseApp | null {
+        return this.app;
+    }
+
+    dispose(): void {
+        if (this.app) {
+            deleteApp(this.app);
+            this.app = null;
+            this.analytics = null;
+        }
+    }
+}


### PR DESCRIPTION
# Changes
- switched analytics init to use named firebase strategy

# How to test
- Run in FTM packaged



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CircleCI configuration with new pipeline parameters and workflows to enhance testing and publishing automation.
  * Streamlined `.gitignore` file with simplified ignore patterns for dependencies, environment files, build outputs, and IDE configuration.
  * Removed legacy HTML entry point and associated static assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->