### PR TITLE
fix: [FM-857] added callback integration via passing as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ player?.addEventListener('completed', (event: Event) => {
 });
 ```
 
+### Pass host callbacks directly
+
+```ts
+const player = document.querySelector('assessment-survey-player');
+
+player?.setHostIntegrationCallbacks?.({
+	onComplete: (payload) => {
+		console.log('Assessment complete', payload.score);
+	},
+	onClose: () => {
+		console.log('Assessment closed');
+	},
+	onRewardTrigger: (payload) => {
+		console.log('Trigger host reward flow', payload.score);
+	},
+});
+```
+
+`onComplete` and `onRewardTrigger` fire from the assessment completion path. Existing `completed` events and legacy `onAssessmentCompleted` callbacks remain supported for backward compatibility.
+
 ## Load and cache only one selected language
 
 Use a single language/content key at a time (for example: `zulu-lettersounds`).
@@ -217,7 +237,7 @@ Overridable via `AppStartupConfig`:
 - Asset/runtime: `assetBaseUrl`, `dataBaseUrl`, `waitForWindowLoad`, `skipLoadingScreen`, `skipStartScreen`
 - Integrations: `enableServiceWorker`, `enableUnityBridge`, `enableAndroidSummary`, `enableParentPostMessage`
 - Host callbacks via `hostIntegrationAdapters`:
-	- `onLoaded`, `onClose`, `onSummaryData`, `onAssessmentCompleted`
+	- `onLoaded`, `onClose`, `onSummaryData`, `onComplete`, `onRewardTrigger`, `onAssessmentCompleted`
 
 Not fully overrideable yet:
 

--- a/README.md
+++ b/README.md
@@ -140,25 +140,27 @@ player?.addEventListener('completed', (event: Event) => {
 });
 ```
 
-### Pass host callbacks directly
+### Subscribe with the element PubSub
 
 ```ts
-const player = document.querySelector('assessment-survey-player');
+import { AssessmentSurveyPlayerElement } from '@curiouslearning/assessment-survey';
 
-player?.setHostIntegrationCallbacks?.({
-	onComplete: (payload) => {
-		console.log('Assessment complete', payload.score);
-	},
-	onClose: () => {
-		console.log('Assessment closed');
-	},
-	onRewardTrigger: (payload) => {
-		console.log('Trigger host reward flow', payload.score);
-	},
+const player = document.querySelector('assessment-survey-player') as AssessmentSurveyPlayerElement;
+
+player?.subscribe(AssessmentSurveyPlayerElement.ONCOMPLETE, (payload) => {
+	console.log('Assessment complete', payload.score);
+});
+
+player?.subscribe(AssessmentSurveyPlayerElement.ONCLOSE, () => {
+	console.log('Assessment closed');
+});
+
+player?.subscribe(AssessmentSurveyPlayerElement.ONREWARDTRIGGER, (payload) => {
+	console.log('Trigger host reward flow', payload.score);
 });
 ```
 
-`onComplete` and `onRewardTrigger` fire from the assessment completion path. Existing `completed` events and legacy `onAssessmentCompleted` callbacks remain supported for backward compatibility.
+`AssessmentSurveyPlayerElement.ONCOMPLETE` and `AssessmentSurveyPlayerElement.ONREWARDTRIGGER` fire from the assessment completion path through the element's internal `@curiouslearning/core` `PubSub`. The exported constants keep the host event names stable: `loaded`, `closed`, `summary`, `completed`, and `reward-trigger`.
 
 ## Load and cache only one selected language
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -64,6 +64,8 @@ export interface HostIntegrationAdapters {
   onLoaded?: () => void;
   onClose?: () => void;
   onSummaryData?: (summary: SummaryData) => void;
+  onComplete?: (payload: AssessmentCompletedPayload) => void;
+  onRewardTrigger?: (payload: AssessmentCompletedPayload) => void;
   onAssessmentCompleted?: (payload: AssessmentCompletedPayload) => void;
 }
 
@@ -429,16 +431,30 @@ export class App {
     this.hostIntegrationAdapters?.onSummaryData?.(summaryData);
   }
 
-  public notifyAssessmentCompleted(score: number): void {
-    const payload: AssessmentCompletedPayload = {
+  public createAssessmentCompletedPayload(score: number): AssessmentCompletedPayload {
+    return {
       type: 'assessment_completed',
       score,
     };
+  }
+
+  public notifyComplete(payload: AssessmentCompletedPayload): void {
+    this.hostIntegrationAdapters?.onComplete?.(payload);
+  }
+
+  public notifyRewardTrigger(payload: AssessmentCompletedPayload): void {
+    this.hostIntegrationAdapters?.onRewardTrigger?.(payload);
+  }
+
+  public notifyAssessmentCompleted(score: number): void {
+    const payload = this.createAssessmentCompletedPayload(score);
 
     if (this.enableParentPostMessage && window.parent) {
       window.parent.postMessage(payload, 'https://synapse.curiouscontent.org/');
     }
 
+    this.notifyComplete(payload);
+    this.notifyRewardTrigger(payload);
     this.hostIntegrationAdapters?.onAssessmentCompleted?.(payload);
   }
 }

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -1,4 +1,5 @@
 import { App, AppStartupConfig, AssessmentCompletedPayload, HostIntegrationAdapters, SummaryData, createApp } from './App';
+import { PubSub } from '@curiouslearning/core';
 import { buildAssessmentSurveyFragment, normalizeBaseUrl, normalizeHostTheme } from './ui/dom-template';
 import { UIController } from '@ui/uiController';
 import { AnalyticsConfig } from '@analytics/base-analytics-integration';
@@ -53,46 +54,42 @@ function getFirstAttributeValue(element: HTMLElement, names: string[]): string |
 }
 
 export class AssessmentSurveyPlayerElement extends HTMLElement {
+  public static readonly ONLOADED = 'loaded';
+  public static readonly ONCLOSE = 'closed';
+  public static readonly ONSUMMARY = 'summary';
+  public static readonly ONCOMPLETE = 'completed';
+  public static readonly ONREWARDTRIGGER = 'reward-trigger';
+
   private appInstance: App | null = null;
   private isInitialized = false;
   private analyticsConfig: AnalyticsConfig | null = null;
-  private hostIntegrationCallbacks: HostIntegrationAdapters = {};
+  private readonly hostIntegrationPubSub = new PubSub();
 
   // exposed method for host app to inject analytics config
   public setAnalyticsConfig(config: AnalyticsConfig): void {
     this.analyticsConfig = config;
   }
 
-  public setHostIntegrationCallbacks(callbacks: HostIntegrationAdapters): void {
-    this.hostIntegrationCallbacks = {
-      ...this.hostIntegrationCallbacks,
-      ...callbacks,
-    };
-
-    if (this.appInstance) {
-      this.appInstance.hostIntegrationAdapters = this.buildHostIntegrationAdapters();
-    }
+  public subscribe<T = unknown>(event: string, callback: (payload: T) => void): () => void {
+    return this.hostIntegrationPubSub.subscribe(event, callback as (data: any) => void);
   }
 
   private buildHostIntegrationAdapters(): HostIntegrationAdapters {
     return {
       onLoaded: () => {
-        this.hostIntegrationCallbacks.onLoaded?.();
-        this.dispatchEvent(new CustomEvent('loaded'));
+        this.hostIntegrationPubSub.publish(AssessmentSurveyPlayerElement.ONLOADED, undefined);
       },
       onClose: () => {
-        this.hostIntegrationCallbacks.onClose?.();
-        this.dispatchEvent(new CustomEvent('closed'));
+        this.hostIntegrationPubSub.publish(AssessmentSurveyPlayerElement.ONCLOSE, undefined);
       },
       onSummaryData: (summaryData: SummaryData) => {
-        this.hostIntegrationCallbacks.onSummaryData?.(summaryData);
-        this.dispatchEvent(new CustomEvent('summary', { detail: summaryData }));
+        this.hostIntegrationPubSub.publish(AssessmentSurveyPlayerElement.ONSUMMARY, summaryData);
       },
-      onComplete: this.hostIntegrationCallbacks.onComplete,
-      onRewardTrigger: this.hostIntegrationCallbacks.onRewardTrigger,
-      onAssessmentCompleted: (payload: AssessmentCompletedPayload) => {
-        this.hostIntegrationCallbacks.onAssessmentCompleted?.(payload);
-        this.dispatchEvent(new CustomEvent('completed', { detail: payload }));
+      onComplete: (payload: AssessmentCompletedPayload) => {
+        this.hostIntegrationPubSub.publish(AssessmentSurveyPlayerElement.ONCOMPLETE, payload);
+      },
+      onRewardTrigger: (payload: AssessmentCompletedPayload) => {
+        this.hostIntegrationPubSub.publish(AssessmentSurveyPlayerElement.ONREWARDTRIGGER, payload);
       },
     };
   }
@@ -159,7 +156,6 @@ export class AssessmentSurveyPlayerElement extends HTMLElement {
     this.appInstance = null;
     this.isInitialized = false;
     this.analyticsConfig = null;
-    this.hostIntegrationCallbacks = {};
     UIController.Reset();
   }
 }

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -70,6 +70,7 @@ export class AssessmentSurveyPlayerElement extends HTMLElement {
     this.analyticsConfig = config;
   }
 
+  // TODO: consider subscribing to the app events directly in the app itself instead of creating a pubsub here at webcomponent
   public subscribe<T = unknown>(event: string, callback: (payload: T) => void): () => void {
     return this.hostIntegrationPubSub.subscribe(event, callback as (data: any) => void);
   }

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -1,4 +1,4 @@
-import { App, AppStartupConfig, createApp } from './App';
+import { App, AppStartupConfig, AssessmentCompletedPayload, HostIntegrationAdapters, SummaryData, createApp } from './App';
 import { buildAssessmentSurveyFragment, normalizeBaseUrl, normalizeHostTheme } from './ui/dom-template';
 import { UIController } from '@ui/uiController';
 import { AnalyticsConfig } from '@analytics/base-analytics-integration';
@@ -56,10 +56,45 @@ export class AssessmentSurveyPlayerElement extends HTMLElement {
   private appInstance: App | null = null;
   private isInitialized = false;
   private analyticsConfig: AnalyticsConfig | null = null;
+  private hostIntegrationCallbacks: HostIntegrationAdapters = {};
 
   // exposed method for host app to inject analytics config
   public setAnalyticsConfig(config: AnalyticsConfig): void {
     this.analyticsConfig = config;
+  }
+
+  public setHostIntegrationCallbacks(callbacks: HostIntegrationAdapters): void {
+    this.hostIntegrationCallbacks = {
+      ...this.hostIntegrationCallbacks,
+      ...callbacks,
+    };
+
+    if (this.appInstance) {
+      this.appInstance.hostIntegrationAdapters = this.buildHostIntegrationAdapters();
+    }
+  }
+
+  private buildHostIntegrationAdapters(): HostIntegrationAdapters {
+    return {
+      onLoaded: () => {
+        this.hostIntegrationCallbacks.onLoaded?.();
+        this.dispatchEvent(new CustomEvent('loaded'));
+      },
+      onClose: () => {
+        this.hostIntegrationCallbacks.onClose?.();
+        this.dispatchEvent(new CustomEvent('closed'));
+      },
+      onSummaryData: (summaryData: SummaryData) => {
+        this.hostIntegrationCallbacks.onSummaryData?.(summaryData);
+        this.dispatchEvent(new CustomEvent('summary', { detail: summaryData }));
+      },
+      onComplete: this.hostIntegrationCallbacks.onComplete,
+      onRewardTrigger: this.hostIntegrationCallbacks.onRewardTrigger,
+      onAssessmentCompleted: (payload: AssessmentCompletedPayload) => {
+        this.hostIntegrationCallbacks.onAssessmentCompleted?.(payload);
+        this.dispatchEvent(new CustomEvent('completed', { detail: payload }));
+      },
+    };
   }
 
   connectedCallback(): void {
@@ -112,12 +147,7 @@ export class AssessmentSurveyPlayerElement extends HTMLElement {
       waitForWindowLoad: false,
       uiRoot: this,
       analyticsConfig: this.analyticsConfig ?? undefined,
-      hostIntegrationAdapters: {
-        onLoaded: () => this.dispatchEvent(new CustomEvent('loaded')),
-        onClose: () => this.dispatchEvent(new CustomEvent('closed')),
-        onSummaryData: (summaryData) => this.dispatchEvent(new CustomEvent('summary', { detail: summaryData })),
-        onAssessmentCompleted: (payload) => this.dispatchEvent(new CustomEvent('completed', { detail: payload })),
-      },
+      hostIntegrationAdapters: this.buildHostIntegrationAdapters(),
     };
 
     this.appInstance = createApp(startupConfig);
@@ -129,6 +159,7 @@ export class AssessmentSurveyPlayerElement extends HTMLElement {
     this.appInstance = null;
     this.isInitialized = false;
     this.analyticsConfig = null;
+    this.hostIntegrationCallbacks = {};
     UIController.Reset();
   }
 }

--- a/test/src/App.test.ts
+++ b/test/src/App.test.ts
@@ -214,6 +214,35 @@ describe('App Class', () => {
 
     (window as any).location = originalLocation;
   });
+
+  test('should notify completion, reward, and legacy assessment callbacks with the same payload', () => {
+    const onComplete = jest.fn();
+    const onRewardTrigger = jest.fn();
+    const onAssessmentCompleted = jest.fn();
+
+    app.hostIntegrationAdapters = {
+      onComplete,
+      onRewardTrigger,
+      onAssessmentCompleted,
+    };
+
+    app.notifyAssessmentCompleted(300);
+
+    const expectedPayload = { type: 'assessment_completed', score: 300 };
+
+    expect(onComplete).toHaveBeenCalledWith(expectedPayload);
+    expect(onRewardTrigger).toHaveBeenCalledWith(expectedPayload);
+    expect(onAssessmentCompleted).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  test('should notify close callback when configured', () => {
+    const onClose = jest.fn();
+    app.hostIntegrationAdapters = { onClose };
+
+    app.notifyClose();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });
 
 function handleServiceWorkerMessage(mockEvent: {


### PR DESCRIPTION
# Changes
- Update FTM assessment integration to use the new direct callback API instead of relying on player lifecycle events.
- Wire `onComplete`, `onRewardTrigger`, and `onClose` through the assessment manager and gameplay flow.
- Refresh the vendored assessment package used by FTM.

# How to test
- Run `npm test`.
- Launch an assessment in FTM and verify load, complete, reward-trigger, and close flows all fire and gameplay resumes correctly.

Ref: [FM-857](https://curiouslearning.atlassian.net/browse/FM-857)


[FM-857]: https://curiouslearning.atlassian.net/browse/FM-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added completion and reward-trigger callbacks for host integrations.
  * Exposed a subscribe(event, callback) API to receive standardized lifecycle events: loaded, closed, summary, completed, reward-trigger.
  * Completion flow now invokes complete and reward-trigger notifications in addition to existing completion notifications.

* **Tests**
  * Added tests verifying completion, reward-trigger and close notifications are invoked with the expected payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->