### PR TITLE
fix: [FM-896] fix assessment audio not cached for offline standalone playback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ workflows:
             branches:
               only:
                 - main
+                - rc
       - build_and_publish:
           context:
             - github-context
@@ -131,3 +132,4 @@ workflows:
             branches:
               only:
                 - main
+                - rc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: npm run build:package
       - run: mkdir -p ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: npx semantic-release@25.0.3 --dry-run --branches "$CIRCLE_BRANCH"
+      - run: npx semantic-release@25.0.3 --dry-run
 
   s3-deploy:
     executor:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "type": "git",
     "url": "https://github.com/curiouslearning/assessment-survey-js.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "curious learning",
   "license": "MIT",
   "bugs": {

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import('semantic-release').GlobalConfig} */
+module.exports = {
+  branches: [
+    'main',
+    {
+      name: 'rc',
+      channel: 'rc',
+      prerelease: 'rc',
+    },
+  ],
+};

--- a/src/App.ts
+++ b/src/App.ts
@@ -237,16 +237,9 @@ export class App {
 
         for (let i = 0; i < buckets.length; i++) {
           for (let j = 0; j < buckets[i].items.length; j++) {
-            let audioItemURL;
-            if (
-              data['quizName'].includes('Luganda') ||
-              data['quizName'].toLowerCase().includes('west african english')
-            ) {
-              audioItemURL = resolveAssetPath(ASSET_PATHS.AUDIO.itemAudio(this.dataURL, buckets[i].items[j].itemName.toLowerCase().trim()));
-            } else {
-              audioItemURL = resolveAssetPath(ASSET_PATHS.AUDIO.itemAudio(this.dataURL, buckets[i].items[j].itemName.trim()));
-            }
-
+            const audioItemURL = resolveAssetPath(
+              ASSET_PATHS.AUDIO.itemAudio(this.dataURL, buckets[i].items[j].itemName.toLowerCase().trim() + '.mp3')
+            );
             this.cacheModel.addItemToAudioVisualResources(audioItemURL);
           }
         }


### PR DESCRIPTION
# Changes
- Assessment item audio URLs registered for service worker caching now include the `.mp3` extension and are normalized to lowercase, matching the URLs that `AudioController` actually fetches at runtime
- Removes the redundant Luganda/West African English conditional, all assessment items now use consistent lowercase + `.mp3` normalization, consistent with how the SW stores cache keys
- Added config for creating a release candidate package


# How to test
- Reload the page online, confirm the loading screen appears and cache fills (Application → Cache Storage → `zulu-lettersounds` should contain `.mp3` entries)
- Enable offline mode in DevTools → Network, reload, audio should play correctly

Ref: [FM-896](https://curiouslearning.atlassian.net/browse/FM-896)


[FM-896]: https://curiouslearning.atlassian.net/browse/FM-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to support release candidate builds alongside production releases, enabling controlled staged rollouts.

* **Refactor**
  * Simplified audio asset path generation for assessment items, improving consistency and removing conditional branching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->