### PR TITLE
fix: FM-891 Two Stars Displayed for a Single Answer Initially

### DIFF
--- a/src/ui/uiController.ts
+++ b/src/ui/uiController.ts
@@ -617,7 +617,15 @@ export class UIController {
   }
 
   public static ChangeStarImageAfterAnimation(): void {
-    var starToShow = document.getElementById('star' + UIController.getInstance().qAnsNum) as HTMLImageElement;
+    const currentStarIndex = UIController.getInstance().qAnsNum - 1;
+    if (currentStarIndex < 0) {
+      return;
+    }
+
+    var starToShow = document.getElementById('star' + currentStarIndex) as HTMLImageElement;
+    if (!starToShow) {
+      return;
+    }
     starToShow.src = resolveAssetPath(ASSET_PATHS.STAR_AFTER_ANIMATION);
   }
 

--- a/test/ui/uiController.test.ts
+++ b/test/ui/uiController.test.ts
@@ -647,16 +647,19 @@ describe('UIController', () => {
     UIController.SetFeedbackVisibile(false, true);
     expect(AudioController.PlayCorrect).not.toHaveBeenCalled();
   });
-  test('should change star image to star_after_animation.gif', () => {
-    const star = document.getElementById('star1') as HTMLImageElement;
-    star.src = 'initial.gif';
+  test('should change the most recently added star image to star_after_animation.gif', () => {
+    const currentStar = document.getElementById('star0') as HTMLImageElement;
+    const nextStar = document.getElementById('star1') as HTMLImageElement;
+    currentStar.src = 'initial.gif';
+    nextStar.src = 'next.gif';
 
     UIController.getInstance().qAnsNum = 1;
     UIController.getInstance().stars = [1, 2, 3, 4, 5];
 
     UIController.ChangeStarImageAfterAnimation();
 
-    expect(star.src).toContain('star_after_animation.gif');
+    expect(currentStar.src).toContain('star_after_animation.gif');
+    expect(nextStar.src).toContain('next.gif');
   });
   test('should add a star with gif and correct style changes', () => {
     const ui = UIController.getInstance();


### PR DESCRIPTION
# Changes
- Fixed the first-answer double-star bug in the star UI flow. The issue was an off-by-one in UI controller
-  changed it to target qAnsNum - 1 and added a small guard for the zero-stars case. Also tightened the regression test so it confirms the current star changes and the next one stays untouched.

# How to test
- Test any assessment on first level

Ref: [FM-891](https://curiouslearning.atlassian.net/browse/FM-891)


[FM-891]: https://curiouslearning.atlassian.net/browse/FM-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug in star image animations that could cause incorrect display or errors in certain scenarios. Star animations now display correctly and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->