### PR TITLE
fix: [FM-885] restore and fix SFX playback on answer selection

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -249,6 +249,8 @@ export class App {
         this.game = new Assessment(this.dataURL, this.unityBridge);
       }
 
+      this.cacheModel.addItemToAudioVisualResources(resolveAssetPath(ASSET_PATHS.AUDIO.dingSfx));
+
       this.game.unityBridge = this.unityBridge;
 
       contentVersion = data['contentVersion'];

--- a/src/components/audioController.ts
+++ b/src/components/audioController.ts
@@ -18,10 +18,13 @@ export class AudioController {
 
   private feedbackAudio: any = null;
   private correctAudio: any = null;
+  private dingAudio: any = null;
 
   private init(): void {
     this.feedbackAudio = new Audio();
     this.correctAudio = new Audio();
+    this.dingAudio = new Audio();
+    this.dingAudio.src = resolveAssetPath(ASSET_PATHS.AUDIO.dingSfx);
   }
 
   public static PrepareAudioAndImagesForSurvey(questionsData: qData[], dataURL: string): void {
@@ -153,15 +156,7 @@ export class AudioController {
   }
 
   public static PlayDing(): void {
-    const instance = AudioController.getInstance();
-    if (instance.feedbackAudio) {
-      AudioController.safePlay(instance.feedbackAudio, 'Ding');
-      return;
-    }
-
-    if (instance.correctAudio) {
-      AudioController.safePlay(instance.correctAudio, 'Ding fallback');
-    }
+    AudioController.safePlay(AudioController.getInstance().dingAudio, 'Ding');
   }
 
   public static PlayCorrect(): void {

--- a/src/config/assetsPaths.ts
+++ b/src/config/assetsPaths.ts
@@ -12,5 +12,6 @@ export const ASSET_PATHS = {
     AUDIO: {
         itemAudio: (dataURL: string, itemName: string) => `audio/${dataURL}/${itemName}`,
         feedbackAudio: (dataURL: string) => `audio/${dataURL}/answer_feedback.mp3`,
+        dingSfx: 'audio/Correct.wav',
     }
 } as const;

--- a/src/ui/uiController.ts
+++ b/src/ui/uiController.ts
@@ -425,8 +425,10 @@ export class UIController {
       if (isCorrect) {
         UIController.getInstance().feedbackContainer.style.color = 'rgb(109, 204, 122)';
         AudioController.PlayCorrect();
+        AudioController.PlayDing();
       } else {
         UIController.getInstance().feedbackContainer.style.color = 'red';
+        AudioController.PlayDing();
       }
     } else {
       UIController.getInstance().feedbackContainer.classList.remove('visible');

--- a/test/components/audioController.test.ts
+++ b/test/components/audioController.test.ts
@@ -104,9 +104,9 @@ describe('AudioController', () => {
     expect(instance.allAudios['bucket-audio.mp3']).toBeInstanceOf(HTMLAudioElement);
   });
 
-  test('PlayDing should play the feedback audio', () => {
+  test('PlayDing should play the ding audio', () => {
     const instance = AudioController.getInstance();
-    const playSpy = jest.spyOn(instance['feedbackAudio'], 'play').mockImplementation();
+    const playSpy = jest.spyOn(instance['dingAudio'], 'play').mockImplementation();
 
     AudioController.PlayDing();
 


### PR DESCRIPTION
# Changes
- SFX (Correct.wav) now plays on both correct and incorrect answer selections;
  previously only correct answers had audio after FM-879 removed PlayDing()
- Wired a dedicated `dingAudio` element to `Correct.wav` so PlayDing() uses
  its own non-language-specific sound file instead of the feedback audio element
- Added `Correct.wav` to the service worker cache model so it is cached
  alongside language assets on first load
- Normalized all item audio paths to lowercase + `.mp3` extension uniformly,
  removing the per-language special-casing for Luganda and West African English

# How to test
- Open `build/index.html`, start an assessment, select a wrong answer →
  confirm Correct.wav plays
- Select a correct answer → confirm Correct.wav plays (in addition to
  the existing correct-answer feedback)
- Open DevTools → Application → Cache Storage, confirm `Correct.wav`
  is present after first load with service worker active


Ref: [FM-885](https://curiouslearning.atlassian.net/browse/FM-885)


[FM-885]: https://curiouslearning.atlassian.net/browse/FM-885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ding sound effect that plays when feedback is displayed (for both correct and incorrect responses)

* **Tests**
  * Updated audio handling tests to reflect new ding sound behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->