### PR TITLE
fixed: Fixed UI displacement position (FM-892).

### DIFF
--- a/src/ui/dom-template.ts
+++ b/src/ui/dom-template.ts
@@ -196,7 +196,9 @@ class AssessmentSurveyTemplateBuilder {
       fragment.appendChild(new StylesheetLinkSection(this.context).render());
     }
 
-    fragment.appendChild(new BodyWrapperSection(this.context).render(true));
+    //To Do: Hook up flag control here pass true in render to use drag and drop feature.
+    // Otherwise pass False or blank for the default select and click survey
+    fragment.appendChild(new BodyWrapperSection(this.context).render());
 
     return fragment;
   }

--- a/src/ui/uiController.ts
+++ b/src/ui/uiController.ts
@@ -558,7 +558,7 @@ export class UIController {
   public static AddStar(): void {
 
     //Add new star to animate and display.
-    UIController.getInstance().qAnsNum += 1;
+    UIController.getInstance().qAnsNum += UIController.getInstance().shownStarsCount;
 
     var starToShow = document.getElementById('star' + UIController.getInstance().qAnsNum) as HTMLImageElement;
     if (!starToShow) {
@@ -617,6 +617,7 @@ export class UIController {
 
     UIController.instance.starPositions.push({ x: randomX, y: randomY });
 
+    //Updated star count.
     UIController.getInstance().shownStarsCount += 1;
   }
 

--- a/src/ui/uiController.ts
+++ b/src/ui/uiController.ts
@@ -558,7 +558,7 @@ export class UIController {
   public static AddStar(): void {
 
     //Add new star to animate and display.
-    UIController.getInstance().qAnsNum += UIController.getInstance().shownStarsCount;
+    UIController.getInstance().qAnsNum = UIController.getInstance().shownStarsCount;
 
     var starToShow = document.getElementById('star' + UIController.getInstance().qAnsNum) as HTMLImageElement;
     if (!starToShow) {

--- a/src/ui/uiController.ts
+++ b/src/ui/uiController.ts
@@ -251,6 +251,7 @@ export class UIController {
     y: number,
     minDistance: number
   ): boolean {
+
     if (starPositions.length < 1) return false;
 
     for (let i = 0; i < starPositions.length; i++) {
@@ -555,6 +556,10 @@ export class UIController {
   }
 
   public static AddStar(): void {
+
+    //Add new star to animate and display.
+    UIController.getInstance().qAnsNum += 1;
+
     var starToShow = document.getElementById('star' + UIController.getInstance().qAnsNum) as HTMLImageElement;
     if (!starToShow) {
       throw new Error('Star element not found');
@@ -587,6 +592,7 @@ export class UIController {
     starToShow.style.top = window.innerHeight / 2 + 'px';
     starToShow.style.left = UIController.instance.gameContainer.offsetWidth / 2 - starToShow.offsetWidth / 2 + 'px';
 
+
     setTimeout(() => {
       starToShow.style.transition = `top ${2 * animationSpeedMultiplier}s ease, left ${2 * animationSpeedMultiplier}s ease, transform ${2 * animationSpeedMultiplier}s ease`;
       if (randomX < containerWidth / 2 - 30) {
@@ -610,8 +616,6 @@ export class UIController {
     }, 1000 * animationSpeedMultiplier);
 
     UIController.instance.starPositions.push({ x: randomX, y: randomY });
-
-    UIController.getInstance().qAnsNum += 1;
 
     UIController.getInstance().shownStarsCount += 1;
   }

--- a/test/ui/_mock_/dom.ts
+++ b/test/ui/_mock_/dom.ts
@@ -5,6 +5,7 @@ export function setupDom() {
     <div id="gameWrap"></div>
     <div id="endWrap"></div>
     <div id="starWrapper">
+      <img id="star0" />
       <img id="star1" />
       <img id="star2" />
       <img id="star3" />

--- a/test/ui/uiController.test.ts
+++ b/test/ui/uiController.test.ts
@@ -498,7 +498,7 @@ describe('UIController', () => {
   });
 
   it('should throw if the star element does not exist (edge case)', () => {
-    uiController.qAnsNum = 99;
+    uiController.shownStarsCount = 99;
 
     expect(() => {
       UIController.AddStar();

--- a/test/ui/uiController.test.ts
+++ b/test/ui/uiController.test.ts
@@ -449,7 +449,7 @@ describe('UIController', () => {
   });
   it('should set the correct image source and classes on the star element', () => {
     uiController.qAnsNum = 0;
-    const star = document.getElementById('star1') as HTMLImageElement;
+    const star = document.getElementById('star0') as HTMLImageElement;
 
     UIController.AddStar();
 
@@ -459,11 +459,11 @@ describe('UIController', () => {
     expect(star.style.position).toBe('absolute');
   });
 
-  it('should increment qAnsNum and shownStarsCount', () => {
+  it('should update qAnsNum and increment shownStarsCount', () => {
     uiController.qAnsNum = 0;
     UIController.AddStar();
 
-    expect(uiController.qAnsNum).toBe(1);
+    expect(uiController.qAnsNum).toBe(0);
     expect(uiController.shownStarsCount).toBe(1);
   });
 
@@ -479,7 +479,7 @@ describe('UIController', () => {
 
   it('should apply transition and transform styles', () => {
     uiController.qAnsNum = 0;
-    const star = document.getElementById('star1') as HTMLImageElement;
+    const star = document.getElementById('star0') as HTMLImageElement;
 
     UIController.AddStar();
 
@@ -664,7 +664,7 @@ describe('UIController', () => {
 
     UIController.AddStar();
 
-    const star = document.getElementById('star1') as HTMLImageElement;
+    const star = document.getElementById('star0') as HTMLImageElement;
     expect(star.src).toContain('Star.gif');
     expect(star.classList.contains('topstarv')).toBe(true);
     expect(star.style.position).toBe('absolute');

--- a/test/ui/uiController.test.ts
+++ b/test/ui/uiController.test.ts
@@ -449,7 +449,7 @@ describe('UIController', () => {
   });
   it('should set the correct image source and classes on the star element', () => {
     uiController.qAnsNum = 0;
-    const star = document.getElementById('star0') as HTMLImageElement;
+    const star = document.getElementById('star1') as HTMLImageElement;
 
     UIController.AddStar();
 
@@ -479,7 +479,7 @@ describe('UIController', () => {
 
   it('should apply transition and transform styles', () => {
     uiController.qAnsNum = 0;
-    const star = document.getElementById('star0') as HTMLImageElement;
+    const star = document.getElementById('star1') as HTMLImageElement;
 
     UIController.AddStar();
 
@@ -664,7 +664,7 @@ describe('UIController', () => {
 
     UIController.AddStar();
 
-    const star = document.getElementById('star0') as HTMLImageElement;
+    const star = document.getElementById('star1') as HTMLImageElement;
     expect(star.src).toContain('Star.gif');
     expect(star.classList.contains('topstarv')).toBe(true);
     expect(star.style.position).toBe('absolute');


### PR DESCRIPTION
# Changes
- Removed passed true value to `BodyWrapperSection`, a residual test value when testing the prepared drag and drop feature.
- Fix premature star display by incrementing `qAnsNum` before selecting the next star in `UIController.AddStar()`.
- Update `uiController` tests to match the new star-selection order.

# How to test
- Run `npm run build` then `npm run develop`
- Open http://localhost:8081/ in browser and start the assessment.
- As per answering the survey, star should properly appear and there will be no UI position displacement.

Ref: [FM-892](https://curiouslearning.atlassian.net/browse/FM-892)


[FM-892]: https://curiouslearning.atlassian.net/browse/FM-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted drag-and-drop behavior for embedded question wrappers.
  * Synchronized star counting to ensure correct star selection and rendering timing.

* **Tests**
  * Updated unit tests and DOM mocks to validate star rendering and the revised counting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->