### PR TITLE
fix: Bug Asset Disappears and Reappears on First Click (FM-912)

### DIFF
--- a/public/css/drag-drop-style.css
+++ b/public/css/drag-drop-style.css
@@ -279,21 +279,23 @@ button {
 }
 
 /* Drag-and-drop UI: ladybug button visuals */
+/* Keep both ladybug assets referenced up front so the pre asset swap rendering stays consistent
+   and does not show a brief decode delay the first time the dragging state appears. */
 .as-ui-mode-new .answerButton {
   padding: 26px 10px 6px;
   color: rgb(255, 255, 255);
   background-color: transparent;
-  background-image: url('../img/ladybug_close.svg');
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
+  background-image: url('../img/ladybug_close.svg'), url('../img/ladybug_open.svg');
+  background-size: contain, 0 0;
+  background-repeat: no-repeat, no-repeat;
+  background-position: center, center;
   transition: none;
   overflow: visible;
   position: relative;
 }
 
 .as-ui-mode-new .answerButton.dragging {
-  background-image: url('../img/ladybug_open.svg');
+  background-size: 0 0, contain;
 }
 
 /* Sparkle ✦ glitter — continuous twinkle around the ladybug edges while dragging.


### PR DESCRIPTION
# Changes
- Updated the CSS style for loading the lady bug assets.

# How to test
-For the first time of loading the drag and drop survey.
-Drag the lady bug options. 
-On first drag, it should properly transition to the other lady bug wings open asset without brief delay.

Ref: [FM-912](https://curiouslearning.atlassian.net/browse/FM-912)


[FM-912]: https://curiouslearning.atlassian.net/browse/FM-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced visual rendering consistency for drag-and-drop interactions, ensuring proper display of ladybug assets during state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->