### PR TITLE
fix: Added a hard cap for max width and height for chest image to avoid oversizing (FM-914)

### DIFF
--- a/public/css/drag-drop-style.css
+++ b/public/css/drag-drop-style.css
@@ -108,6 +108,11 @@ body.assessment-survey-standalone {
   object-fit: contain;
 }
 
+.as-ui-mode-new #chestImage {
+  max-width: 380px;
+  max-height: 380px;
+}
+
 .starWrapper {
   width: 100%;
   margin-top: 60px;


### PR DESCRIPTION
…

# Changes
- Added a max width and height for the chest image to avoid sizes getting too big.
- Ensured the fix only applies to drag and drop UI. 

# How to test
- Open the assessment survey on larger screens.
- See that the chest image wont resize past 380px. 

Ref: [FM-914](https://curiouslearning.atlassian.net/browse/FM-914)


[FM-914]: https://curiouslearning.atlassian.net/browse/FM-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chest image display size constraints for improved layout consistency in the new UI mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->