### PR TITLE
fix: Fixed Multiple Options Can Be Selected and Dragged Simultaneously

### DIFF
--- a/src/ui/drag-drop/dom-events/drag-controller.ts
+++ b/src/ui/drag-drop/dom-events/drag-controller.ts
@@ -72,7 +72,7 @@ export default class DragEventController {
     }
 
     private handlePointerDown = (event: PointerEvent) => {
-        if (this.locked) return;
+        if (this.locked && this.foundDragElement) return;
 
         this.foundDragElement = this.locateBtnElement(event);
 


### PR DESCRIPTION
# Changes
- Added `this.foundDragElement` as a flag to stop `handlePointerDown` from executing once there is an active element found.

# How to test
- Start the assessment in mobile.
- When the options shows up, pressed down on multiple options and try to drag them.
- The first button pressed down should be the only thing that should react and be dragged while the rest stays in the same position.

Ref: [FM-920](https://curiouslearning.atlassian.net/browse/FM-920)


[FM-920]: https://curiouslearning.atlassian.net/browse/FM-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved drag and drop interaction handling to provide more responsive behavior during locked states, allowing new drag operations to begin appropriately while preventing interference with existing drags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->