### PR TITLE
fix: Updated Fixed Multiple Options Can Be Selected and Dragged Simul…

### DIFF
--- a/src/ui/drag-drop/dom-events/drag-controller.ts
+++ b/src/ui/drag-drop/dom-events/drag-controller.ts
@@ -6,6 +6,7 @@ export default class DragEventController {
     private targetDropElement: iDropAreaHTMLElement | null = null;
     private foundDragElement: iDraggableHTMLElement | null = null;
     private locked = false;
+    private activePointerId: number | null = null;
 
     constructor(private root: HTMLElement) {
         this.targetDropElement = this.getDropTarget();
@@ -32,6 +33,7 @@ export default class DragEventController {
         this.root.removeEventListener('pointercancel', this.handlePointerCancel);
         this.foundDragElement = null;
         this.targetDropElement = null;
+        this.activePointerId = null;
     }
 
     private locateBtnElement(event: PointerEvent): iDraggableHTMLElement | null {
@@ -71,18 +73,24 @@ export default class DragEventController {
         chestImage.src = chestImage.src.replace(/TreasureChestOpen[\w-]+\.svg/, `${variant}.svg`);
     }
 
+    private isActivePointer(event: PointerEvent): boolean {
+        return this.activePointerId !== null && event.pointerId === this.activePointerId;
+    }
+
     private handlePointerDown = (event: PointerEvent) => {
-        if (this.locked && this.foundDragElement) return;
+        if (this.locked) return;
+        if (this.activePointerId !== null || this.foundDragElement) return;
 
-        this.foundDragElement = this.locateBtnElement(event);
+        const dragElement = this.locateBtnElement(event);
 
-        if (this.foundDragElement) {
-            this.foundDragElement?.onStart(event);
-            // Open the chest lid as soon as a drag begins
-            this.setChestImage('TreasureChestOpen04-new');
-            appEventBus.publish(appEventBus.EVENTS.ON_DRAG_START, true);
-        }
+        if (!dragElement) return;
 
+        this.activePointerId = event.pointerId;
+        this.foundDragElement = dragElement;
+        this.foundDragElement?.onStart(event);
+        // Open the chest lid as soon as a drag begins
+        this.setChestImage('TreasureChestOpen04-new');
+        appEventBus.publish(appEventBus.EVENTS.ON_DRAG_START, true);
     };
 
     private isWithinTargetArea(
@@ -104,7 +112,7 @@ export default class DragEventController {
 
     private handlePointerDragMove = (event: PointerEvent) => {
         //Returns none if there are no answer button element.
-        if (!this.foundDragElement) return;
+        if (!this.foundDragElement || !this.isActivePointer(event)) return;
 
         //Trigger the on move to move the button element.
         this.foundDragElement?.onMove(event);
@@ -116,7 +124,9 @@ export default class DragEventController {
         }
     };
 
-    private handlePointerUp = (_event: PointerEvent) => {
+    private handlePointerUp = (event: PointerEvent) => {
+        if (!this.isActivePointer(event)) return;
+
         const dropContext = this.getActiveDropContext();
         if (dropContext) {
             // Dragged element released over the drop zone — commit the answer selection
@@ -129,17 +139,21 @@ export default class DragEventController {
         this.endDrag();
     };
 
-    private handlePointerCancel = (_event: PointerEvent) => {
+    private handlePointerCancel = (event: PointerEvent) => {
+        if (!this.isActivePointer(event)) return;
+
         this.endDrag();
     };
 
     private endDrag(): void {
         if (!this.foundDragElement) {
+            this.activePointerId = null;
             return;
         }
 
         this.foundDragElement?.onEnd?.();
         this.foundDragElement = null;
+        this.activePointerId = null;
         // Close the chest lid once the drag interaction is over
         this.setChestImage('TreasureChestOpen01-new');
     };

--- a/test/ui/drag-controller.test.ts
+++ b/test/ui/drag-controller.test.ts
@@ -2,8 +2,19 @@ import DragEventController from '@ui/drag-drop/dom-events/drag-controller';
 import type { iDraggableHTMLElement } from '@ui/drag-drop/dom-events/draggable-button';
 import type { iDropAreaHTMLElement } from '@ui/drag-drop/dom-events/drop-target';
 
-const createPointerLikeEvent = (type: string, init: MouseEventInit = {}): PointerEvent =>
-  new MouseEvent(type, init) as PointerEvent;
+const createPointerLikeEvent = (
+  type: string,
+  init: MouseEventInit = {},
+  pointerId = 1,
+): PointerEvent => {
+  const event = new MouseEvent(type, init) as PointerEvent;
+  Object.defineProperty(event, 'pointerId', {
+    configurable: true,
+    value: pointerId,
+  });
+
+  return event;
+};
 
 describe('DragEventController', () => {
   let root: HTMLElement;
@@ -150,5 +161,22 @@ describe('DragEventController', () => {
 
     expect(dropArea.onDrop).not.toHaveBeenCalled();
     expect(button.onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a second pointerdown while another drag is active', () => {
+    const secondButton = document.createElement('div') as iDraggableHTMLElement;
+    secondButton.className = 'answerButton';
+    secondButton.onStart = jest.fn();
+    secondButton.onMove = jest.fn();
+    secondButton.onEnd = jest.fn();
+    root.appendChild(secondButton);
+
+    new DragEventController(root).attach();
+
+    button.dispatchEvent(createPointerLikeEvent('pointerdown', { bubbles: true }, 1));
+    secondButton.dispatchEvent(createPointerLikeEvent('pointerdown', { bubbles: true }, 2));
+
+    expect(button.onStart).toHaveBeenCalledTimes(1);
+    expect(secondButton.onStart).not.toHaveBeenCalled();
   });
 });

--- a/test/ui/drag-controller.test.ts
+++ b/test/ui/drag-controller.test.ts
@@ -179,4 +179,39 @@ describe('DragEventController', () => {
     expect(button.onStart).toHaveBeenCalledTimes(1);
     expect(secondButton.onStart).not.toHaveBeenCalled();
   });
+
+  it('ignores pointermove from a different pointer while a drag is active', () => {
+    new DragEventController(root).attach();
+
+    button.dispatchEvent(createPointerLikeEvent('pointerdown', { bubbles: true }, 1));
+    button.dispatchEvent(createPointerLikeEvent('pointermove', { bubbles: true }, 2));
+
+    expect(button.onMove).not.toHaveBeenCalled();
+  });
+
+  it('ignores pointerup from a different pointer while a drag is active', () => {
+    new DragEventController(root).attach();
+
+    button.dispatchEvent(createPointerLikeEvent('pointerdown', { bubbles: true }, 1));
+    button.dispatchEvent(createPointerLikeEvent('pointerup', { bubbles: true }, 2));
+
+    expect(button.onEnd).not.toHaveBeenCalled();
+    expect(dropArea.onDrop).not.toHaveBeenCalled();
+
+    button.dispatchEvent(createPointerLikeEvent('pointermove', { bubbles: true }, 1));
+    expect(button.onMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores pointercancel from a different pointer while a drag is active', () => {
+    new DragEventController(root).attach();
+
+    button.dispatchEvent(createPointerLikeEvent('pointerdown', { bubbles: true }, 1));
+    button.dispatchEvent(createPointerLikeEvent('pointercancel', { bubbles: true }, 2));
+
+    expect(button.onEnd).not.toHaveBeenCalled();
+    expect(dropArea.onDrop).not.toHaveBeenCalled();
+
+    button.dispatchEvent(createPointerLikeEvent('pointermove', { bubbles: true }, 1));
+    expect(button.onMove).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# Changes
- Added single active pointer ownership fix by adding `activePointerId`
- Added a hard check to prevent multi touch event by cross checking the active event id versus pointer event id; `this.activePointerId !== null && event.pointerId === this.activePointerId`

# How to test
- Start the assessment in mobile.
- When the options shows up, pressed down on multiple options and try to drag them.
- The first button pressed down should be the only thing that should react and be dragged while the rest stays in the same position.

Ref: [FM-920](https://curiouslearning.atlassian.net/browse/FM-920)


[FM-920]: https://curiouslearning.atlassian.net/browse/FM-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag handling stability by ensuring drag operations only respond to the pointer that initiated them, preventing interference from other pointer events during active drags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->