### PR TITLE
fix: FM-915 Old Chest UI Appears at End of Full Assessment.

### DIFF
--- a/src/ui/drag-drop/dragdrop-ui.ts
+++ b/src/ui/drag-drop/dragdrop-ui.ts
@@ -386,11 +386,7 @@ export class DragDropAssessmentUI implements AssessmentUI {
   progressChest(): void {
     const chestImage = this.root.querySelector<HTMLImageElement>('#chestImage');
     if (!chestImage) return;
-
-    const match = chestImage.src.match(/TreasureChestOpen(\d+)/);
-    const currentNum = match ? parseInt(match[1], 10) : NaN;
-    const nextNum = isNaN(currentNum) ? 1 : (currentNum % 4) + 1;
-    chestImage.src = resolveAssetPath(ASSET_PATHS.CHEST_PROGRESSION_NEW[nextNum as 1 | 2 | 3 | 4]);
+    chestImage.src = resolveAssetPath(ASSET_PATHS.CHEST_PROGRESSION_NEW[4]);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/src/ui/uiController.ts
+++ b/src/ui/uiController.ts
@@ -647,16 +647,7 @@ export class UIController {
 
   public static ProgressChest() {
     const chestImage = UIController.getInstance().getElementById<HTMLImageElement>('chestImage');
-    let currentImgSrc = chestImage.src;
-    console.log('Chest Progression-->', chestImage);
-    console.log('Chest Progression-->', chestImage.src);
-    const currentImageNumber = parseInt(currentImgSrc.slice(-6, -4), 10);
-    console.log('Chest Progression number-->', currentImageNumber);
-    const nextImageNumber = (currentImageNumber % 4) + 1;
-    const nextImageSrc = Number.isNaN(nextImageNumber)
-      ? resolveAssetPath(`img/chestprogression/TreasureChestOpen0${String(nextImageNumber)}.svg`)
-      : resolveAssetPath(ASSET_PATHS.CHEST_PROGRESSION[nextImageNumber]);
-    chestImage.src = nextImageSrc;
+    chestImage.src = resolveAssetPath(ASSET_PATHS.CHEST_PROGRESSION[4]);
   }
 
   public static SetContentLoaded(value: boolean): void {

--- a/test/ui/uiController.test.ts
+++ b/test/ui/uiController.test.ts
@@ -242,29 +242,15 @@ describe('UIController', () => {
     expect(getInstanceSpy).toHaveBeenCalled();
     getInstanceSpy.mockRestore();
   });
-  it('should update chest image source to the next one', () => {
-    UIController.ProgressChest();
-    expect(chestImage.src).toContain('http://localhost/img/chestprogression/TreasureChestOpen0NaN.svg');
-  });
-
-  it('should loop from 04 to 01', () => {
-    chestImage.src = 'img/chestprogression/TreasureChestOpen04.svg';
-    UIController.ProgressChest();
-    expect(chestImage.src).toContain('http://localhost/img/chestprogression/TreasureChestOpen01.svg');
-  });
-
-  it('should extract correct current image number and increment', () => {
-    chestImage.src = 'img/chestprogression/TreasureChestOpen03.svg';
+  it('should always set chest image to TreasureChestOpen04 on completion', () => {
     UIController.ProgressChest();
     expect(chestImage.src).toContain('http://localhost/img/chestprogression/TreasureChestOpen04.svg');
   });
 
-  it('should default to image 01 if current number is invalid', () => {
-    chestImage.src = 'img/chestprogression/InvalidName.svg';
+  it('should set chest to TreasureChestOpen04 regardless of current image', () => {
+    chestImage.src = 'img/chestprogression/TreasureChestOpen01.svg';
     UIController.ProgressChest();
-    // Depending on how parseInt behaves, this might become NaN.
-    // So you might want to guard in actual code.
-    expect(chestImage.src).toContain('http://localhost/img/chestprogression/TreasureChestOpen0NaN.svg'); // <- can write a fallback in real code
+    expect(chestImage.src).toContain('http://localhost/img/chestprogression/TreasureChestOpen04.svg');
   });
   it('should add 20 stars with correct IDs and class', () => {
     const uiController = UIController.getInstance();


### PR DESCRIPTION
# Changes
- Fixed  Old Chest UI Appears at End of Full Assessment by new UI.

# How to test
- Play the whole assessment and see the last chest image

Ref: [FM-915](https://curiouslearning.atlassian.net/browse/FM-915)


[FM-915]: https://curiouslearning.atlassian.net/browse/FM-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined chest progression mechanics to consistently display the final opened chest state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->