### PR TITLE
fix: [MR-84] added appVersion to be passed to the Container Firestore

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -352,6 +352,7 @@ export class App {
             max_score: gameInstance.max_score,
             time_spent: endTime - startTime,
             event_type: 'activity_completed',
+            app_version: appVersion,
           });
         }
       });


### PR DESCRIPTION
# Changes
- added appVersion to be passed to the Container Firestore

# How to test
- Complete an assessment in the Android App using the CRContainer then check if the new data stored in Firebase has the app_version

Ref: [MR-84](https://curiouslearning.atlassian.net/browse/MR-84)


[MR-84]: https://curiouslearning.atlassian.net/browse/MR-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced app analytics with version information tracking to improve diagnostic data collection during assessment sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->