### PR TITLE
fix: FM-916 Long press draggable image issue fixed and placeholder answer button on first load with service worker issue fixed

### DIFF
--- a/public/css/drag-drop-style.css
+++ b/public/css/drag-drop-style.css
@@ -418,6 +418,13 @@ button {
   height: 96%;
 }
 
+/* Prevent browser native image drag (long-press ghost image) on all assets */
+.bodyWrapper img {
+  -webkit-user-drag: none;
+  user-select: none;
+  pointer-events: none;
+}
+
 #nextqButton {
   background-color: rgba(0, 0, 0, 0);
   border: none;

--- a/src/App.ts
+++ b/src/App.ts
@@ -172,6 +172,15 @@ export class App {
       UIController.ConfigureRoot(this.uiRoot);
     }
 
+    // In new-UI mode DragDropAssessmentUI owns the game-start flow.
+    // UIController.gameReady defaults to true, so its landing click handler would
+    // call UIController.showGame() (setting #gameWrap display:grid) before
+    // DragDropAssessmentUI.showGame() runs, causing DragDropAssessmentUI to hit
+    // its idempotent guard and skip callbacks.onStart() entirely.
+    if (this.assessmentUIMode === 'new-ui') {
+      UIController.SetGameReady(false);
+    }
+
     // Controller uses the same resolved mode — no independent flag check.
     this.assessmentUI.dispose?.();
     this.assessmentUI = this.createAssessmentUI();
@@ -386,6 +395,23 @@ export class App {
         });
 
       navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
+
+      // Instance-bound handler so this.assessmentUI (new-UI path) also receives
+      // loading progress signals that arrive via the SW→client message channel.
+      navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
+        if (event.data.msg === 'Loading') {
+          const progressValue = parseInt(event.data.data.progress);
+          if (progressValue >= 100) {
+            this.assessmentUI.setLoadingProgress(100);
+            setTimeout(() => {
+              this.assessmentUI.setLoadingVisible(false);
+              this.assessmentUI.setContentLoaded(true);
+            }, skipLoadingScreen ? 0 : 1500);
+          } else if (progressValue >= 10) {
+            this.assessmentUI.setLoadingProgress(progressValue);
+          }
+        }
+      });
 
       await navigator.serviceWorker.ready;
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -102,6 +102,7 @@ export class App {
   private assessmentUI: AssessmentUI;
   private uiRoot: Document | ShadowRoot | HTMLElement = document;
   private templateConfig: Omit<AssessmentSurveyTemplateConfig, 'assessmentUIMode'> = {};
+  private swMessageHandler: ((event: MessageEvent) => void) | null = null;
 
   lang: string = 'english';
 
@@ -398,7 +399,10 @@ export class App {
 
       // Instance-bound handler so this.assessmentUI (new-UI path) also receives
       // loading progress signals that arrive via the SW→client message channel.
-      navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
+      if (this.swMessageHandler) {
+        navigator.serviceWorker.removeEventListener('message', this.swMessageHandler);
+      }
+      this.swMessageHandler = (event: MessageEvent) => {
         if (event.data.msg === 'Loading') {
           const progressValue = parseInt(event.data.data.progress);
           if (progressValue >= 100) {
@@ -411,7 +415,8 @@ export class App {
             this.assessmentUI.setLoadingProgress(progressValue);
           }
         }
-      });
+      };
+      navigator.serviceWorker.addEventListener('message', this.swMessageHandler);
 
       await navigator.serviceWorker.ready;
 
@@ -506,7 +511,11 @@ export class App {
   }
 
   public dispose(): void {
-    this.assessmentUI.dispose?.(); 
+    if (this.swMessageHandler) {
+      navigator.serviceWorker.removeEventListener('message', this.swMessageHandler);
+      this.swMessageHandler = null;
+    }
+    this.assessmentUI.dispose?.();
   }
 
   /**

--- a/src/components/audioController.ts
+++ b/src/components/audioController.ts
@@ -61,6 +61,7 @@ export class AudioController {
     console.log('Add image: ' + newImageURL);
     let newImage = new Image();
     newImage.src = resolveAssetPath(newImageURL);
+    newImage.draggable = false;
     AudioController.getInstance().allImages[newImageURL] = newImage;
   }
 

--- a/src/ui/dom-template/assessment-template-engine.ts
+++ b/src/ui/dom-template/assessment-template-engine.ts
@@ -170,6 +170,13 @@ export class TemplateContext {
   public resolveAsset(path: string): string {
     return withBase(this.config.assetBaseUrl, path, this.config.rootRelativeAssetPaths);
   }
+
+  /**
+   * Returns a derived context with the given sections overrides applied.
+   */
+  public withSections(override: Partial<TemplateSections>): TemplateContext {
+    return new TemplateContext({ ...this.config, sections: { ...this.config.sections, ...override } });
+  }
 }
 
 /**

--- a/src/ui/dom-template/sections/drag-drop/drag-drop-body-wrapper-section.ts
+++ b/src/ui/dom-template/sections/drag-drop/drag-drop-body-wrapper-section.ts
@@ -5,6 +5,7 @@ import { DevModeBucketInfoSection } from '../shared/dev-mode-bucket-info-section
 import { DevModeToggleButtonSection } from '../shared/dev-mode-toggle-button-section';
 import { DevModeSettingsModalSection } from '../shared/dev-mode-settings-modal-section';
 import { DraggableQuestionViewWrapperSection } from './draggable-question-view-wrapper-section';
+import { LoadingScreenSection } from '../shared/loading-screen-section';
 
 /**
  * Composes the drag-and-drop gameplay sections into the body wrapper.
@@ -21,8 +22,14 @@ export class DragDropBodyWrapperSection extends TemplateSection<HTMLDivElement> 
       ),
     });
 
+    // Loading screen is placed at body-wrapper level so `position:absolute` covers
+    // the full app viewport (bodyWrapper has position:relative), not just the landing section.
+    // LandingPageWrapperSection receives a context with loadingScreen:false to avoid a duplicate #loadingScreen.
+    const landingContext = this.context.withSections({ loadingScreen: false });
+
     appendChildren(bodyWrapper, [
-      new LandingPageWrapperSection(this.context).render(),
+      this.context.sections.loadingScreen ? new LoadingScreenSection(this.context).render() : null,
+      new LandingPageWrapperSection(landingContext).render(),
       new DraggableQuestionViewWrapperSection(this.context).render(),
       this.context.sections.endingScreen ? new EndingPageWrapperSection(this.context).render() : null,
       new DevModeBucketInfoSection(this.context).render(),

--- a/src/ui/dom-template/sections/drag-drop/draggable-question-view-wrapper-section.ts
+++ b/src/ui/dom-template/sections/drag-drop/draggable-question-view-wrapper-section.ts
@@ -25,6 +25,7 @@ export class DraggableQuestionViewWrapperSection extends TemplateSection<HTMLDiv
                 id: 'chestImage',
                 attrs: {
                     src: this.context.resolveAsset('img/chestprogression/TreasureChestOpen01-new.svg'),
+                    draggable: 'false',
                 },
             })
         );

--- a/src/ui/drag-drop/dom-events/drag-controller.ts
+++ b/src/ui/drag-drop/dom-events/drag-controller.ts
@@ -24,6 +24,7 @@ export default class DragEventController {
         this.root.addEventListener('pointermove', this.handlePointerDragMove);
         this.root.addEventListener('pointerup', this.handlePointerUp);
         this.root.addEventListener('pointercancel', this.handlePointerCancel);
+        this.root.addEventListener('dragstart', this.handleDragStart);
     }
 
     public detach(): void {
@@ -31,6 +32,7 @@ export default class DragEventController {
         this.root.removeEventListener('pointermove', this.handlePointerDragMove);
         this.root.removeEventListener('pointerup', this.handlePointerUp);
         this.root.removeEventListener('pointercancel', this.handlePointerCancel);
+        this.root.removeEventListener('dragstart', this.handleDragStart);
         this.foundDragElement = null;
         this.targetDropElement = null;
         this.activePointerId = null;
@@ -76,6 +78,12 @@ export default class DragEventController {
     private isActivePointer(event: PointerEvent): boolean {
         return this.activePointerId !== null && event.pointerId === this.activePointerId;
     }
+
+    //suppress the browser's native HTML5 drag on any element inside
+    // the game container so only the custom pointer-event drag can fire.
+    private handleDragStart = (event: DragEvent) => {
+        event.preventDefault();
+    };
 
     private handlePointerDown = (event: PointerEvent) => {
         if (this.locked) return;

--- a/src/ui/drag-drop/dragdrop-ui.ts
+++ b/src/ui/drag-drop/dragdrop-ui.ts
@@ -197,6 +197,10 @@ export class DragDropAssessmentUI implements AssessmentUI {
     this.landingContainer.style.display = 'none';
     this.gameContainer.style.display = 'grid';
     this.endContainer.style.display = 'none';
+    // Hide answer buttons immediately so placeholder text is never visible before the
+    // first question is prepared (guards against any frame painted before onStart fires).
+    this.answersContainer.style.visibility = 'hidden';
+    this.answerButtons.forEach((b) => (b.style.visibility = 'hidden'));
     this.allStart = Date.now();
     this.callbacks?.onStart();
   }

--- a/src/ui/drag-drop/dragdrop-ui.ts
+++ b/src/ui/drag-drop/dragdrop-ui.ts
@@ -226,7 +226,7 @@ export class DragDropAssessmentUI implements AssessmentUI {
         );
       });
     } else {
-      this.playButton.innerHTML = `<button id='nextqButton'><img class="audio-button" width='100px' height='100px' src='${resolveAssetPath(ASSET_PATHS.SOUND_BUTTON_IDLE_NEW)}' type='image/svg+xml'></img></button>`;
+      this.playButton.innerHTML = `<button id='nextqButton'><img class="audio-button" draggable="false" width='100px' height='100px' src='${resolveAssetPath(ASSET_PATHS.SOUND_BUTTON_IDLE_NEW)}' type='image/svg+xml'></img></button>`;
       const nextBtn = this.playButton.querySelector('#nextqButton') as HTMLElement;
       nextBtn?.addEventListener('click', () => {
         this.revealQuestion();
@@ -257,7 +257,7 @@ export class DragDropAssessmentUI implements AssessmentUI {
     // Replace the play button handler so subsequent clicks only replay audio
     // without re-hiding the answer buttons (matches UIController.ShowQuestion behavior).
     if (!this.devModeBucketControlsEnabled) {
-      this.playButton.innerHTML = `<button id='nextqButton'><img class="audio-button" width='100px' height='100px' src='${resolveAssetPath(ASSET_PATHS.SOUND_BUTTON_IDLE_NEW)}' type='image/svg+xml'></img></button>`;
+      this.playButton.innerHTML = `<button id='nextqButton'><img class="audio-button" draggable="false" width='100px' height='100px' src='${resolveAssetPath(ASSET_PATHS.SOUND_BUTTON_IDLE_NEW)}' type='image/svg+xml'></img></button>`;
       const replayBtn = this.playButton.querySelector('#nextqButton') as HTMLElement;
       replayBtn?.addEventListener('click', () => {
         AudioController.PlayAudio(
@@ -341,6 +341,7 @@ export class DragDropAssessmentUI implements AssessmentUI {
     let img = this.playButton.querySelector('img') as HTMLImageElement;
     if (!img) {
       img = document.createElement('img');
+      img.draggable = false;
       this.playButton.appendChild(img);
     }
     img.src = resolveAssetPath(


### PR DESCRIPTION
# Changes
-  FM-916 Long Press Creates Draggable Mirror Image of Chest and Audio Button (In mid and low end devices)
- FM-916 Placeholder answer buttons shown on first load with service worker caching issue fixed

# How to test
- Play the assessment load first time and see if caching is creating any data loading issue
- Drag assessts while playing game

Ref: [FM-916](https://curiouslearning.atlassian.net/browse/FM-916)


[FM-916]: https://curiouslearning.atlassian.net/browse/FM-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled native image dragging across the application to prevent unintended "ghost" image behavior on long-press actions
  * Improved game state initialization and loading screen handling for drag-drop assessments
  * Fixed answer button display timing during state transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/assessment-survey-js/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->