### PR TITLE
fix: Large Screen UI Issue — Chest Appears Oversized in Assessment and Small in Mini-Game

### DIFF
--- a/public/css/drag-drop-style.css
+++ b/public/css/drag-drop-style.css
@@ -109,8 +109,8 @@ body.assessment-survey-standalone {
 }
 
 .as-ui-mode-new #chestImage {
-  max-width: 380px;
-  max-height: 380px;
+  max-width: 260px;
+  max-height: 260px;
 }
 
 .starWrapper {
@@ -283,6 +283,10 @@ button {
   overflow: hidden;
 }
 
+.as-ui-mode-new .answerContainer {
+  justify-items: center !important;
+}
+
 /* Drag-and-drop UI: ladybug button visuals */
 /* Keep both ladybug assets referenced up front so the pre asset swap rendering stays consistent
    and does not show a brief decode delay the first time the dragging state appears. */
@@ -297,6 +301,9 @@ button {
   transition: none;
   overflow: visible;
   position: relative;
+  width: 100%;
+  max-width: 105px;
+  justify-self: center;
 }
 
 .as-ui-mode-new .answerButton.dragging {


### PR DESCRIPTION
# Changes
- Updated the max width and height of treasure chest of drag and drop to 280px to prevent image from going too large.
- Added a max size also for the answer option to compliment the max width and height of the treasure chest.

# How to test
- Test method 1

Ref: [FM-914](https://curiouslearning.atlassian.net/browse/FM-914)


[FM-914]: https://curiouslearning.atlassian.net/browse/FM-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ