### PR TITLE
fix: Standalone Assessment app shows Blue screen prior to loader (FM-918)

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
         </div>
       </div>
     </div>
-  </div>
 
     <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-DGTWM534Z4"></script>
 	<script>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,15 @@
       data-show-devmode-bucket-info="true"
       data-show-devmode-toggle-button="true"
       data-show-devmode-settings="true"
-    ></div>
+    >
+     <div id="loadingScreen">
+        <img id="loading-gif" src="assets/img/loadingImg.gif" alt="Loading Animation" />
+        <div id="progressBarContainer">
+          <div id="progressBar"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 
     <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-DGTWM534Z4"></script>
 	<script>

--- a/src/ui/dom-template/sections/drag-drop/drag-drop-body-wrapper-section.ts
+++ b/src/ui/dom-template/sections/drag-drop/drag-drop-body-wrapper-section.ts
@@ -27,11 +27,8 @@ export class DragDropBodyWrapperSection extends TemplateSection<HTMLDivElement> 
     // LandingPageWrapperSection receives a context with loadingScreen:false to avoid a duplicate #loadingScreen.
     const landingContext = this.context.withSections({ loadingScreen: false });
 
-    if (this.context.sections.loadingScreen) {
-      bodyWrapper.appendChild(new LoadingScreenSection(this.context).render());
-    }
-
     appendChildren(bodyWrapper, [
+      this.context.sections.loadingScreen ? new LoadingScreenSection(this.context).render() : null,
       new LandingPageWrapperSection(landingContext).render(),
       new DraggableQuestionViewWrapperSection(this.context).render(),
       this.context.sections.endingScreen ? new EndingPageWrapperSection(this.context).render() : null,

--- a/src/ui/dom-template/sections/shared/loading-screen-section.ts
+++ b/src/ui/dom-template/sections/shared/loading-screen-section.ts
@@ -2,11 +2,7 @@ import { appendChildren, createElement, TemplateSection } from '../../assessment
 
 export class LoadingScreenSection extends TemplateSection<HTMLDivElement> {
   public render(): HTMLDivElement {
-    const loadingScreen = createElement('div', {
-      id: 'loadingScreen',
-      style:
-        'position:absolute;top:0;left:0;width:100%;height:100%;display:flex;justify-content:center;align-items:center;z-index:100;background-color:white;flex-direction:column',
-    });
+    const loadingScreen = createElement('div', { id: 'loadingScreen' });
     const loadingGif = createElement('img', {
       id: 'loading-gif',
       attrs: {


### PR DESCRIPTION
# Changes
- Prioritized loading screen to prevent blank (blue screen) from appearing by adding the loading screen directly at the html file.

# How to test
- Run assessment survey
- Upon loading there should be no visible bluescreen even for a split seconds.
- The loading should be rendered as soon as the app starts.


Ref: [FM-918](https://curiouslearning.atlassian.net/browse/FM-918)


[FM-918]: https://curiouslearning.atlassian.net/browse/FM-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading screen to the assessment/survey standalone page, including a loading GIF and progress bar.

* **Refactor**
  * Improved organization of loading screen components for maintainability.
  * Removed inline styling from the loading element to separate styles from markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->