### PR TITLE
feat: [MR-83] register container_app_version as a Firebase user property

### DIFF
--- a/src/analytics/base-analytics-integration.ts
+++ b/src/analytics/base-analytics-integration.ts
@@ -1,4 +1,5 @@
 import { AnalyticsService, FirebaseStrategy, StatsigStrategy } from '@curiouslearning/analytics';
+import { getContainerAppVersion } from '@utils/urlUtils';
 
 export interface AnalyticsConfig {
     firebaseName: string;
@@ -10,6 +11,7 @@ export interface AnalyticsConfig {
     messagingSenderId: string;
     appId: string;
     measurementId: string;
+    container_app_version?: string;
 }
 
 /**
@@ -54,6 +56,8 @@ export class BaseAnalyticsIntegration {
         }
 
         try {
+            const containerAppVersion = config.container_app_version ?? getContainerAppVersion() ?? '';
+
             this.firebaseStrategy = new FirebaseStrategy({
                 firebaseName: config.firebaseName,
                 firebaseOptions: {
@@ -66,7 +70,9 @@ export class BaseAnalyticsIntegration {
                     appId: config.appId,
                     measurementId: config.measurementId,
                 },
-                userProperties: {}
+                userProperties: {
+                    container_app_version: containerAppVersion
+                }
             });
 
             await this.firebaseStrategy.initialize();

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -11,6 +11,7 @@ export type RuntimeConfigOverrides = {
   endpoint?: string;
   organization?: string;
   assessmentUIMode?: string;
+  container_app_version?: string;
 };
 
 let runtimeConfigOverrides: RuntimeConfigOverrides = {};
@@ -120,6 +121,10 @@ export function getAssessmentUIMode(): 'legacy' | 'new-ui' | null {
     return value;
   }
   return null;
+}
+
+export function getContainerAppVersion(): string | null {
+  return getConfigValue('container_app_version');
 }
 
 function getPathName() {


### PR DESCRIPTION
# Changes
- Add `container_app_version` to the `AnalyticsConfig` interface and the `RuntimeConfigOverrides` URL-parsing type, plus a `getContainerAppVersion()` accessor in `src/utils/urlUtils.ts`.
- Register the resolved value as a Firebase user property via the `FirebaseStrategy` constructor's `userProperties` option.

# How to test
- npm run dev and load `http://localhost:8081/?container_app_version=3.24.1`. Confirm in Firebase Realtime / DebugView (project `ftm-b9d99`) that `Container App Version` shows on assessment events.
- BigQuery (after ~24h propagation): `container_app_version` should land on `opened`, `initialized`, `answered`, `bucketCompleted`, `completed`, etc., on the assessment-web stream.

Ref: [MR-83](https://curiouslearning.atlassian.net/browse/MR-83)


[MR-83]: https://curiouslearning.atlassian.net/browse/MR-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ